### PR TITLE
Add ability to customize ktor plugins without overriding default configs

### DIFF
--- a/src/test/kotlin/dev/merge/client/shared/AdditionalPluginsForApiClientTests.kt
+++ b/src/test/kotlin/dev/merge/client/shared/AdditionalPluginsForApiClientTests.kt
@@ -1,0 +1,93 @@
+package dev.merge.client.shared
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.merge.client.shared.ExampleCustomKtorPlugin.Config
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.plugin
+import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.util.AttributeKey
+import io.ktor.util.KtorDsl
+import java.util.logging.Logger
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.superclasses
+import kotlin.reflect.jvm.isAccessible
+import kotlin.test.*
+
+class AdditionalPluginsForApiClientTests {
+
+    @Test
+    fun `Should be able to install additional ktor plugins`() {
+        // given
+        val wrapper = TestApiClient()
+        val configurationSpy = ConfigurationSpy()
+
+        // when
+        wrapper.addKtorPlugin(ExampleCustomKtorPlugin) { configurationSpy.configure() }
+
+        // then
+        val client = wrapper.getHttpClient()
+
+        // first, prove the default content negotiation plugin is still installed.
+        val contentNegotiationPlugin = client.plugin(ContentNegotiation)
+        assertNotNull(contentNegotiationPlugin, "The base ContentNegotiation plugin should still be installed.")
+
+        // now extract our extra plugin.
+        val exampleCustomKtorPlugin = client.plugin(ExampleCustomKtorPlugin)
+        assertNotNull(exampleCustomKtorPlugin, "The custom plugin should have been installed.")
+
+        assertTrue(configurationSpy.configured, "Should have called any configuration required on the plugin.")
+    }
+}
+
+class TestApiClient: ApiClient("https://example.com", null, null, jacksonObjectMapper()) {
+    // extract the ktor http client for test purposes only.
+    fun getHttpClient() =  this::class.superclasses
+        .first { it.simpleName == "ApiClient" }
+        .declaredMemberProperties.first { it.name == "client" }
+        .apply{ isAccessible = true }.getter.call(this) as HttpClient
+}
+
+/**
+ * Extremely basic request / response logging plugin.
+ */
+class ExampleCustomKtorPlugin internal constructor(private val config: Config) {
+
+    class Config {
+        val property: String = "my-value"
+    }
+
+    @KtorDsl
+    companion object Plugin : HttpClientPlugin<Config, ExampleCustomKtorPlugin> {
+
+        private val logger = Logger.getLogger("ExampleCustomKtorPlugin")
+
+        override val key: AttributeKey<ExampleCustomKtorPlugin> = AttributeKey("ExampleCustomKtorPlugin")
+
+        override fun install(plugin: ExampleCustomKtorPlugin, scope: HttpClient) {
+            scope.responsePipeline.intercept(HttpResponsePipeline.After) {
+                val request = context.request
+                val response = context.response
+
+                this@Plugin.logger.info("Request to ${request.url} complete with status: ${response.status}")
+            }
+        }
+
+        override fun prepare(block: Config.() -> Unit): ExampleCustomKtorPlugin {
+            val config = Config().apply(block)
+            return ExampleCustomKtorPlugin(config)
+        }
+    }
+}
+
+/**
+ * Lightweight spy object to ensure we are calling our configure function.
+ */
+class ConfigurationSpy() {
+    var configured = false
+
+    fun configure() {
+        configured = true
+    }
+}


### PR DESCRIPTION
## Description of the change

> Instead of an all-or-nothing approach to ktor client configuration, we should be able to install additional ktor plugins 'later'.
>
> Right now, if we wanted to customize the ktor client in any way (like add request logging, metrics, etc.), we are left with no choice but to override the default ktor configuration that is set up by Merge to handle Content Negotiation.
>
> As a downstream user of this SDK, I do not want to override the default Http client configuration, but I do want to extend it's usage with my own custom Ktor plugins if needed.
>
> This change will allow me to supply my own Ktor plugins to the Merge SDK for things like request logging, etc., without requiring that I take over the configuration of Content Negotiation as well.
>
> Requiring the latter would mean that if Merge decided to change something about their serialization / deserialization, any overrides I copied to my own project just to add additional plugins could cause the SDK to misbehave for me (because I would have had to copy Content Negotiation as well to customize).

> A possible extension of this change (which I would fully support) would be to:
>
> a) disallow the end user to override the underlying Http client on creation, as the ContentNegotiation configuration this SDK already does is important.
> b) `addKtorPlugin` should probably eventually reject trying to re-install `ContentNegotiation` , as this should be decided by the SDK only.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed
> Unit tests demonstrate installing a basic request logging ktor plugin.

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
