### PR TITLE
Makes ApiClient implement Closeable and AutoCloseable, and closes the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,34 @@ val hrisEmployeesResponse = employeesApi.employeesListExpanded(EmployeesApi.Empl
 Using this feature looks very similar to the expands feature, in that you will be receiving raw JsonNode values and will
 need to deserialize to `String` yourself for the enum fields that are using the "remote field" functionality.
 
+### Resource cleanup
+
+Each api client you create needs to allocate some resources. You should close the clients after use to dispose of those resources. 
+
+```java
+// using try / finally
+AccountsApi accountsApi = null;
+
+try {
+  accountsApi = new AccountsApi();
+  ...
+} finally {
+  if (accountsApi != null) {
+    accountsApi.close()  
+  }
+}
+
+// or using try-with-resources
+
+try (AccountsApi accountsApi = new AccountsApi()) {
+  ...
+}
+```
+
+```kotlin
+// using the `use` function
+AccountsApi().use { 
+    ...
+}
+
+```

--- a/src/test/kotlin/dev/merge/client/shared/ApiClientCleanupTests.kt
+++ b/src/test/kotlin/dev/merge/client/shared/ApiClientCleanupTests.kt
@@ -1,0 +1,33 @@
+package dev.merge.client.shared
+
+import dev.merge.client.accounting.apis.AccountsApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ApiClientCleanupTests {
+
+    @Test
+    fun `Should close ktor client threads`() {
+        // count how many threads exist, we might have some open by previous tests
+        val startThreadsCount = countKtorClientThread()
+
+        // this should start a few threads
+        val accountsApi = AccountsApi()
+
+        assertTrue(countKtorClientThread() > startThreadsCount)
+
+        // this should release the threads
+        accountsApi.close()
+        assertEquals(countKtorClientThread(), startThreadsCount)
+    }
+
+    private fun countKtorClientThread(): Int {
+        return Thread.getAllStackTraces().keys
+            .filter {
+                it.name.equals("Ktor-client-apache")
+            }
+            .size
+
+    }
+}


### PR DESCRIPTION
… http client to free up some resources.

## Description of the change

> See issue #16. Essentially the Api clients do no clean-up after themselves and can leak up threads because each new instance creates a new HTTP engine. This PR adds a close function and makes ApiClient implement Closeable and AutoCloseable so that we can use Java and Kotlin idioms. I am not super happy with the unit test, since it might get thrown off if there are multiple tests running in parallel, but this was my major concern.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
